### PR TITLE
Improve way to create network isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ The user is responsible to clean the environment manually when finished. This ca
 By default, the library provides a base .tf file with some flexibility when it comes to creating the domains.
 It is possible to define the number of domains, the source image, the number of Cores and RAM but sometimes the test needs a different configuration (e.g. 2 NICs in the domains, 2 libvirt Networks, etc.). Therefore, it is possible to place a custom .tf file in the same directory as the python module for the test. The library will check that there is a .tf file and will load it instead of the default one.
 
-The custom .tf file must be similar to the one located in `qatrfm/config/simple_1net.tf` when it comes to input and output variables. However, it is possible to hardcode some of them such as Cores, RAM, etc. but it is recommended to leave intact some of them such as `image`, `basename` and `network`.
+The custom .tf file must be similar to the one located in `qatrfm/config/default.tf` when it comes to input and output variables. However, it is possible to hardcode some of them such as Cores, RAM, etc. but it is recommended to leave intact some of them such as `image`, `basename` and `network`.
 
 Also, the output data that defines the domain names is mandatory in this file and must be present:
 

--- a/qatrfm/cli.py
+++ b/qatrfm/cli.py
@@ -98,9 +98,9 @@ def cli(test, path, image, num_domains, cores, ram, snapshots, no_clean):
                 "\t\t  Image  : {}\n"
                 "\t\t  Cores  : {}\n"
                 "\t\t  RAM    : {}\n"
-                "\t\t  Network: {}\n"
+                "\t\t  Network: 10.{}.0.0/24\n"
                 .format(test, env.workdir, not no_clean, snapshots,
-                        num_domains, image, cores, ram, env.networks[0]))
+                        num_domains, image, cores, ram, env.net_octet))
 
     failed_tests = []
 
@@ -133,5 +133,5 @@ def cli(test, path, image, num_domains, cores, ram, snapshots, no_clean):
                          format(failed_tests))
             sys.exit(TrfmTestCase.EX_FAILURE)
         else:
-            logger.success("Overall status = GREEN")
+            logger.success("All tests passed")
             sys.exit(TrfmTestCase.EX_OK)

--- a/qatrfm/config/default.tf
+++ b/qatrfm/config/default.tf
@@ -1,8 +1,8 @@
-variable "count" {
-    default = "2"
+variable "num_domains" {
+    default = "1"
 }
 
-variable "network" {
+variable "net_octet" {
 }
 
 variable "image" {
@@ -25,7 +25,7 @@ provider "libvirt" {
 
 resource "libvirt_volume" "myvdisk" {
   name = "qatrfm-vdisk-${var.basename}-${count.index}.qcow2"
-  count = "${var.count}"
+  count = "${var.num_domains}"
   pool = "default"
   source = "${var.image}"
   format = "qcow2"
@@ -33,7 +33,7 @@ resource "libvirt_volume" "myvdisk" {
 
 resource "libvirt_network" "my_net" {
    name = "qatrfm-net-${var.basename}"
-   addresses = ["${var.network}"]
+   addresses = ["10.${var.net_octet}.0.0/24"]
    dhcp {
         enabled = true
     }
@@ -43,7 +43,7 @@ resource "libvirt_domain" "domain-sle" {
   name = "qatrfm-vm-${var.basename}-${count.index}"
   memory = "${var.ram}"
   vcpu = "${var.cores}"
-  count = "${var.count}"
+  count = "${var.num_domains}"
 
   network_interface {
     network_id = "${libvirt_network.my_net.id}"

--- a/tests/examples/custom/custom.py
+++ b/tests/examples/custom/custom.py
@@ -14,6 +14,8 @@ class CustomTest(TrfmTestCase):
 
     def run(self):
         self.logger.info('Running test case {}'.format(self.name))
-        vm = self.env.domains[0]
-        [retcode, output] = vm.execute_cmd('ip address show')
+        vm1 = self.env.domains[0]
+        vm2 = self.env.domains[1]
+        vm1.execute_cmd('ip address show')
+        vm2.execute_cmd('ip address show')
         return self.EX_OK


### PR DESCRIPTION
Before, I was having a quick way to create networks but it was not really efficient.

This way allows the user to create custom .tf files with up to 255 networks.

The range used for the environments is 10.X.Y.0/24:
- X is calculated by the tool automatically and given to the .tf file as net_octet.
- The default .tf files uses  Y=0  since it creates only 1 libvirt network.
- Y can be used to create different networks in the same environment (see custom.tf) 

Proof run with custom.py https://pastebin.com/raw/ffbuuXvY