### PR TITLE
Add --base-working-dir parameter

### DIFF
--- a/qatrfm/cli.py
+++ b/qatrfm/cli.py
@@ -58,7 +58,11 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 @click.option('--no-clean', 'no_clean', is_flag=True,
               help="Don't clean the environment when the tests finish. "
               "This is useful for debug and troubleshooting.")
-def cli(test, path, image, num_domains, cores, ram, snapshots, no_clean):
+@click.option('--base-working-dir', default='/root/terraform',
+              help='Specify base folder for working directory. This folder'
+              'need write permissions')
+def cli(test, path, image, num_domains, cores, ram, snapshots, no_clean,
+        base_working_dir):
     """ Create a terraform environment and run the test(s)"""
 
     logger = QaTrfmLogger.getQatrfmLogger(__name__)
@@ -69,10 +73,11 @@ def cli(test, path, image, num_domains, cores, ram, snapshots, no_clean):
     for file in os.listdir(basedir):
         if file.endswith(".tf"):
             tf_file = os.path.join(basedir, file)
-    env = TerraformEnv(image=image,
+    env = TerraformEnv(image=os.path.abspath(image),
                        tf_file=tf_file,
                        num_domains=num_domains,
-                       snapshots=snapshots)
+                       snapshots=snapshots,
+                       base_dir=base_working_dir)
 
     spec = importlib.util.spec_from_file_location(filename, path)
     module = importlib.util.module_from_spec(spec)

--- a/qatrfm/utils/libutils.py
+++ b/qatrfm/utils/libutils.py
@@ -40,7 +40,7 @@ class TrfmSnapshotFailed(Exception):
     pass
 
 
-def execute_bash_cmd(cmd, timeout=300, exit_on_failure=True):
+def execute_bash_cmd(cmd, timeout=300, exit_on_failure=True, cwd=os.getcwd()):
     logger.debug("Bash command: '{}'".format(cmd))
     output = ''
 
@@ -54,7 +54,8 @@ def execute_bash_cmd(cmd, timeout=300, exit_on_failure=True):
 
     p = subprocess.Popen(cmd, shell=True,
                          stdout=subprocess.PIPE,
-                         stderr=subprocess.STDOUT)
+                         stderr=subprocess.STDOUT,
+                         cwd=cwd)
     timer = Timer(timeout, timer_finished, args=[p])
     timer.start()
     for line in iter(p.stdout.readline, b''):

--- a/tests/examples/simple/simple_test.py
+++ b/tests/examples/simple/simple_test.py
@@ -22,8 +22,10 @@ class SimpleTest(TrfmTestCase):
 
         # Transfering a file from a VM
         vm1.transfer_file(remote_file_path='/etc/resolv.conf',
-                          local_file_path='/root/test.resolv.conf',
+                          local_file_path=self.env.workdir / 'resolv.conf',
                           type='get')
+        with open(self.env.workdir / 'resolv.conf', 'r') as f:
+            logger.success("Got file: {}".format(f.read()))
 
         # Transfer file to a VM
         vm1.transfer_file(remote_file_path='/root/test_file',


### PR DESCRIPTION
This allow to specifiy the base workingdirectory. It is used to build
the working directory in TerraformEnv.

Working with absolute directories and avoid os.chdir() to make `__file__`
calls possible and also working cleanup.

This is how I called qatrfm as unprivileged user:
`qatrfm -i images/sle-15-SP1-x86_64-186.1-terraform@64bit.qcow2 -p tests/examples/simple/simple_test.py -t SimpleTest --base-working-dir working_dir`