### PR TITLE
Allow adding any input variable for the TF file

### DIFF
--- a/qatrfm/environment.py
+++ b/qatrfm/environment.py
@@ -34,38 +34,29 @@ class TerraformEnv(object):
     logger = QaTrfmLogger.getQatrfmLogger(__name__)
     BASEDIR = '/root/terraform/'
 
-    def __init__(self, image, tf_file=None, num_domains=1,
-                 cores=1, ram=1024, snapshots=False):
+    def __init__(self, tf_vars, tf_file=None, snapshots=False):
         """Initialize Terraform Environment object."""
-        self.image = image
-        if (not os.path.isfile(self.image)):
-            self.logger.error("Image file {} not found.".format(self.image))
-            sys.exit(-1)
-
-        if (tf_file is None):
-            path = os.path.dirname(os.path.realpath(__file__))
-            self.tf_file = ("{}/config/default.tf".format(path))
-        else:
-            self.tf_file = tf_file
-
-        if (not os.path.isfile(self.tf_file)):
-            self.logger.error("File {} not found.".format(self.tf_file))
-            sys.exit(-1)
-        self.logger.debug("Terraform TF file: {}".format(self.tf_file))
-        self.num_domains = num_domains
-        self.cores = cores
-        self.ram = ram
+        self.tf_file = tf_file
+        self.tf_vars = self.vars_to_string(tf_vars)
+        self.logger.info("Terraform TF file: {}".format(self.tf_file))
         self.snapshots = snapshots
         letters = string.ascii_lowercase
         self.basename = ''.join(random.choice(letters) for i in range(10))
         self.workdir = self.BASEDIR + self.basename
         os.makedirs(self.workdir)
-        self.logger.debug("Using working directory {}".format(self.workdir))
+        self.logger.info("Using working directory {}".format(self.workdir))
         shutil.copy(self.tf_file, self.workdir + '/env.tf')
         os.chdir(self.workdir)
         self.domains = []
         self.net_octet = self.get_network_octet()
         self.logger.debug("Using network 10.{}.0.0/24".format(self.net_octet))
+
+    @staticmethod
+    def vars_to_string(vars):
+        s = ''
+        for v in vars:
+            s += "-var '{}' ".format(v)
+        return s
 
     @staticmethod
     def get_network_octet():
@@ -143,14 +134,8 @@ class TerraformEnv(object):
 
         try:
             cmd = ("terraform apply -auto-approve "
-                   "-var \"basename={}\" "
-                   "-var \"image={}\" "
-                   "-var \"net_octet={}\" "
-                   "-var \"cores={}\" "
-                   "-var \"ram={}\" "
-                   "-var \"num_domains={}\"".
-                   format(self.basename, self.image, self.net_octet,
-                          self.cores, self.ram, self.num_domains))
+                   "-var 'basename={}' -var 'net_octet={}' {}".
+                   format(self.basename, self.net_octet, self.tf_vars))
             if ('LOG_COLORS' not in os.environ):
                 cmd = ("{} -no-color".format(cmd))
             [ret, output] = libutils.execute_bash_cmd(cmd, timeout=400)
@@ -204,14 +189,8 @@ class TerraformEnv(object):
                         shutil.rmtree(self.workdir)
                         raise(e)
             cmd = ("terraform destroy -auto-approve "
-                   "-var \"basename={}\" "
-                   "-var \"image={}\" "
-                   "-var \"net_octet={}\" "
-                   "-var \"cores={}\" "
-                   "-var \"ram={}\" "
-                   "-var \"num_domains={}\"".
-                   format(self.basename, self.image, self.net_octet,
-                          self.cores, self.ram, self.num_domains))
+                   "-var 'basename={}' -var 'net_octet={}' {}".
+                   format(self.basename, self.net_octet, self.tf_vars))
             if ('LOG_COLORS' not in os.environ):
                 cmd = ("{} -no-color".format(cmd))
             try:

--- a/qatrfm/utils/libutils.py
+++ b/qatrfm/utils/libutils.py
@@ -40,6 +40,10 @@ class TrfmSnapshotFailed(Exception):
     pass
 
 
+class TrfmMissingVariable(Exception):
+    pass
+
+
 def execute_bash_cmd(cmd, timeout=300, exit_on_failure=True):
     logger.debug("Bash command: '{}'".format(cmd))
     output = ''

--- a/tests/examples/custom/custom.py
+++ b/tests/examples/custom/custom.py
@@ -5,6 +5,26 @@ from qatrfm.utils.logger import QaTrfmLogger
 
 logger = QaTrfmLogger.getQatrfmLogger(__name__)
 
+""" Custom test example
+
+This example test shows how to use a custom .tf file for Terraform.
+The .tf file should be placed in the same directory as this python file
+and the library will detect it and use it.
+
+For custom .tf files, it is important keep using the 2 variables
+'net_octet' and 'basename'. Otherwise, it losses the capability of this tool
+to create isolation between other concurrent tests.
+
+The 2 networks are created using the range 10.X.Y.0/24.
+The second octet (X) is calculated using variable net_octet and this allows
+having the third octet (Y) customizable up to 255 possible networks for
+the environment.
+
+The example custom .tf file also creates 2 domains with different images
+defined by 2 input variables "image1" and "image2"
+
+"""
+
 
 class CustomTest(TrfmTestCase):
 
@@ -17,5 +37,7 @@ class CustomTest(TrfmTestCase):
         vm1 = self.env.domains[0]
         vm2 = self.env.domains[1]
         vm1.execute_cmd('ip address show')
+        vm1.execute_cmd('cat /etc/os-release')
         vm2.execute_cmd('ip address show')
+        vm2.execute_cmd('cat /etc/os-release')
         return self.EX_OK

--- a/tests/examples/custom/custom.tf
+++ b/tests/examples/custom/custom.tf
@@ -1,10 +1,15 @@
+# mandatory variables calculated by the tool
 variable "net_octet" {
 }
 
-variable "image" {
+variable "basename" {
 }
 
-variable "basename" {
+# mandatory custom variables given to the CLI using --tfvar
+variable "image1" {
+}
+
+variable "image2" {
 }
 
 provider "libvirt" {
@@ -13,11 +18,12 @@ provider "libvirt" {
 
 resource "libvirt_volume" "myvdisk" {
   name = "qatrfm-vdisk-${var.basename}-${count.index}.qcow2"
-  count = 2
   pool = "default"
-  source = "${var.image}"
+  count = 2
+  source = "${count.index == 0 ? var.image1 : var.image2}"
   format = "qcow2"
 }
+
 
 resource "libvirt_network" "my_net1" {
    name = "qatrfm-net-${var.basename}-1"
@@ -45,13 +51,11 @@ resource "libvirt_domain" "domain-sle" {
 
   network_interface {
     network_id = "${libvirt_network.my_net1.id}"
-    #network_name = "qatrfm-net-${var.basename}-1"
     wait_for_lease = true
   }
 
   network_interface {
     network_id = "${libvirt_network.my_net2.id}"
-    #network_name = "qatrfm-net-${var.basename}-2"
     wait_for_lease = true
   }
 


### PR DESCRIPTION
Remove mandatory and optional parameters `--image`, `--cpu`, `--ram`, `--num_domains` and make them "optional" using `--tfvar` flag. Of course, for non-custom .tf files, variable "image" is mandatory and it will fail if not provided with `--tfvar image=X`

This way, we are 100% flexible when it comes to provide custom .tf files. 

This PR also shows how to use 2 different disks for 2 VMs in the custom.py test case making use of this new feature with `--tfvar image1=X --tfvar image2=Y`

Proof runs:
  simple:  https://pastebin.com/raw/BCasyuLb
  custom: https://pastebin.com/raw/8mncL7nr