### PR TITLE
Use temp folder as working dir for bash command execution

### DIFF
--- a/qatrfm/environment.py
+++ b/qatrfm/environment.py
@@ -23,6 +23,7 @@ import shutil
 import string
 import sys
 import time
+import tempfile
 
 from qatrfm.domain import Domain
 from qatrfm.utils.logger import QaTrfmLogger
@@ -32,7 +33,6 @@ from qatrfm.utils import libutils
 class TerraformEnv(object):
 
     logger = QaTrfmLogger.getQatrfmLogger(__name__)
-    BASEDIR = '/root/terraform/'
 
     def __init__(self, tf_vars, tf_file=None, snapshots=False):
         """Initialize Terraform Environment object."""
@@ -42,9 +42,8 @@ class TerraformEnv(object):
         self.snapshots = snapshots
         letters = string.ascii_lowercase
         self.basename = ''.join(random.choice(letters) for i in range(10))
-        self.workdir = self.BASEDIR + self.basename
-        os.makedirs(self.workdir)
-        self.logger.info("Using working directory {}".format(self.workdir))
+        self.workdir = tempfile.mkdtemp()
+        self.logger.debug("Using working directory {}".format(self.workdir))
         shutil.copy(self.tf_file, self.workdir + '/env.tf')
         os.chdir(self.workdir)
         self.domains = []

--- a/qatrfm/utils/libutils.py
+++ b/qatrfm/utils/libutils.py
@@ -40,11 +40,7 @@ class TrfmSnapshotFailed(Exception):
     pass
 
 
-class TrfmMissingVariable(Exception):
-    pass
-
-
-def execute_bash_cmd(cmd, timeout=300, exit_on_failure=True):
+def execute_bash_cmd(cmd, timeout=300, exit_on_failure=True, cwd=os.getcwd()):
     logger.debug("Bash command: '{}'".format(cmd))
     output = ''
 
@@ -58,7 +54,7 @@ def execute_bash_cmd(cmd, timeout=300, exit_on_failure=True):
 
     p = subprocess.Popen(cmd, shell=True,
                          stdout=subprocess.PIPE,
-                         stderr=subprocess.STDOUT)
+                         stderr=subprocess.STDOUT, cwd=cwd)
     timer = Timer(timeout, timer_finished, args=[p])
     timer.start()
     for line in iter(p.stdout.readline, b''):


### PR DESCRIPTION
covering two things :
1. replace hardcoded folder under root dir with tempfile.mkdtemp for running Terraform files 
2. execute_bash_cmd will use tempfile.mkdtemp as working dir