### PR TITLE
Absolute path for file variables

### DIFF
--- a/qatrfm/environment.py
+++ b/qatrfm/environment.py
@@ -24,6 +24,7 @@ import string
 import sys
 import time
 import tempfile
+from pathlib import Path
 
 from qatrfm.domain import Domain
 from qatrfm.utils.logger import QaTrfmLogger
@@ -53,7 +54,10 @@ class TerraformEnv(object):
     def vars_to_string(vars):
         s = ''
         for v in vars:
-            s += "-var '{}' ".format(v)
+            kv = v.split('=', 1)
+            if (Path(kv[1]).is_file()):
+                kv[1] = Path(kv[1]).resolve()
+            s += "-var '{}={}' ".format(kv[0], kv[1])
         return s
 
     @staticmethod

--- a/tests/examples/simple/simple_test.py
+++ b/tests/examples/simple/simple_test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import os
+from pathlib import Path
 
 from qatrfm.testcase import TrfmTestCase
 from qatrfm.utils.logger import QaTrfmLogger
@@ -21,9 +22,11 @@ class SimpleTest(TrfmTestCase):
         vm1 = self.env.domains[0]
 
         # Transfering a file from a VM
+        out_file = Path(self.env.workdir) / 'resolv.conf'
         vm1.transfer_file(remote_file_path='/etc/resolv.conf',
-                          local_file_path='/root/test.resolv.conf',
+                          local_file_path=out_file,
                           type='get')
+        logger.success(out_file.read_text())
 
         # Transfer file to a VM
         vm1.transfer_file(remote_file_path='/root/test_file',


### PR DESCRIPTION
As our working directory isn't the same as where we run the `*.tf` file from.  We need to  copy all files to the working directory, preventing the relative folder structure or make the pathes as absolute.

This PR is using the absolute approach. 