### PR TITLE
Load all found TrfmTestCase's automatically

### DIFF
--- a/qatrfm/cli.py
+++ b/qatrfm/cli.py
@@ -17,11 +17,10 @@ one command that creates the environment runs the tests.
 import click
 import importlib.util
 import inspect
-import os
 import sys
+from pathlib import Path
 
 from qatrfm.environment import TerraformEnv
-from qatrfm.utils import libutils
 from qatrfm.utils.logger import QaTrfmLogger, init_logging
 from qatrfm.testcase import TrfmTestCase
 
@@ -34,23 +33,58 @@ def print_version(ctx, param, value):
     ctx.exit()
 
 
-def check_image(vars):
-    for var in vars:
-        v = var.split("=")
-        if (v[0] == 'image'):
-            if (not os.path.isfile(v[1])):
-                raise FileNotFoundError("No such image file {}".format(v[1]))
-            return True
-    raise libutils.TrfmMissingVariable(
-        "TF Parameter 'image' must be provided: "
-        "qatrfm ....  --tfvar image=<image_path>")
+def find_corresponding_tf_file(f: Path):
+    assert(f.is_file())
+    default_tf = Path(__file__).resolve().parent / 'config' / 'default.tf'
+    tf_files = sorted(f.parent.glob('*.tf'))
+    if len(tf_files) > 1:
+        QaTrfmLogger.getQatrfmLogger(__name__).warning(
+                'Found more then one *.tf file for {}'.format(str(f)))
+    if len(tf_files):
+        return tf_files[0]
+    return default_tf
 
 
-def find_tf_file(basedir):
-    for file in os.listdir(basedir):
-        if file.endswith(".tf"):
-            return os.path.join(basedir, file)
-    return None
+def find_py_files(directory: Path):
+    assert(directory.is_dir())
+    file_list = []
+    for x in directory.iterdir():
+        if x.is_file() and x.suffix == '.py':
+            file_list.append(x.resolve())
+        elif x.is_dir():
+            file_list.extend(find_py_files(x))
+    return file_list
+
+
+def load_testcases(basedir: Path, files):
+    assert(basedir.is_dir())
+    testcases = {}
+    for i in files:
+        name = str(i.relative_to(basedir))[:-3].replace('/', '.')
+        tf_file = find_corresponding_tf_file(i)
+        if tf_file not in testcases.keys():
+            testcases[tf_file] = []
+        spec = importlib.util.spec_from_file_location(str(name), i)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        sys.modules[str(name)] = mod
+
+        for member in inspect.getmembers(mod, predicate=inspect.isclass):
+            if (member[1].__module__ == str(name) and
+                    issubclass(member[1], TrfmTestCase)):
+                testcases[tf_file].append(member[1])
+    return testcases
+
+
+def find_testcases(opt_test: Path):
+    opt_test = opt_test.resolve()
+    basedir = opt_test.parent
+    if opt_test.is_dir():
+        basedir = opt_test
+        files = find_py_files(opt_test)
+    else:
+        files = [opt_test]
+    return load_testcases(basedir, files)
 
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'],
@@ -63,8 +97,6 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'],
 @click.option('--test', '-t', required=True,
               help='Testcase(s) name(s). Single name or a list separated by '
               'comas of the Class(es) in path to be executed.')
-@click.option('--path', '-p', required=True,
-              help='Path of the test file.')
 @click.option('--tfvar', type=str, multiple=True, help='Variable to '
               'insert to the .tf file. It can be used multiple times '
               'for each single variable. At least tfvar "image" should be '
@@ -81,84 +113,62 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'],
               default='DEBUG', help="Specify default log level")
 @click.option('--log-colors', 'logcolors', is_flag=True, help="Show different "
               "loglevels in different colors", envvar='LOG_COLORS')
-def cli(test, path, tfvar, snapshots, no_clean, loglevel, logcolors):
+def cli(test, tfvar, snapshots, no_clean, loglevel, logcolors):
     """ Create a terraform environment and run the test(s)"""
 
     init_logging(loglevel, logcolors)
     logger = QaTrfmLogger.getQatrfmLogger(__name__)
-    test_array = test.split(',')
 
-    basedir, filename = os.path.split(path)
+    testcases = find_testcases(Path(test))
+    for tf_file in testcases.keys():
+        env = TerraformEnv(tf_vars=tfvar, tf_file=tf_file, snapshots=snapshots)
+        logger.info(("Test case information:\n"
+                     "\tTF_file      : {}\n"
+                     "\tTests        : {}\n"
+                     "\tWorking dir. : {}\n"
+                     "\tNetwork      : 10.{}.0.0/24\n"
+                     "\tClean        : {}\n"
+                     "\tSnapshots    : {}\n"
+                     "\tTF variables : \n"
+                     "{}").format(
+                          str(tf_file),
+                          ",".join([t.__name__ for t in testcases[tf_file]]),
+                          env.workdir,
+                          env.net_octet, not no_clean, snapshots,
+                          "\n".join(["\t\t{}".format(v) for v in tfvar])
+                   ))
 
-    tf_file = find_tf_file(basedir)
+        try:
+            failed_tests = []
+            env.deploy()
+            for test in testcases[tf_file]:
+                logger.info("Running test case '{}'".format(test.__name__))
+                logger.info("\tfrom module '{}' ".
+                            format(sys.modules[test.__module__].__file__))
 
-    if (tf_file is None):
-        path_tf = os.path.dirname(os.path.realpath(__file__))
-        tf_file = ("{}/config/default.tf".format(path_tf))
-        check_image(tfvar)
-    if (not os.path.isfile(tf_file)):
-        raise FileNotFoundError("No such file {}".format(tf_file))
+                t = test(env, test.__name__)
+                exit_code = t.run()
+                if (exit_code == TrfmTestCase.EX_OK):
+                    logger.success("The test '{}' finished successfuly".
+                                   format(t.name))
+                else:
+                    failed_tests.append(t.name)
+                    logger.error("The test '{}' finished with error code={}".
+                                 format(t.name, exit_code))
 
-    env = TerraformEnv(tf_vars=tfvar, tf_file=tf_file, snapshots=snapshots)
+        except Exception as e:
+            logger.error("Something went wrong:\n{}".format(e))
+            if (not no_clean):
+                env.clean()
+            raise(e)
 
-    spec = importlib.util.spec_from_file_location(filename, path)
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    testcases = []
-    for t in test_array:
-        cls = None
-        for member in inspect.getmembers(module):
-            if member[0] == t:
-                cls = member[1]
-        if (cls is None):
-            sys.exit("There is no Class named '{}' in {}".format(t, path))
-        testcases.append(cls(env, t))
-
-    msg = ("Test case information:\n"
-           "\t\tTest case(s) : {}\n"
-           "\t\tTests path   : {}\n"
-           "\t\tWorking dir. : {}\n"
-           "\t\tNetwork      : 10.{}.0.0/24\n"
-           "\t\tClean        : {}\n"
-           "\t\tSnapshots    : {}\n"
-           "\t\tTF variables :\n"
-           .format(test, path, env.workdir, env.net_octet,
-                   not no_clean, snapshots))
-    for var in tfvar:
-        msg += "\t\t    {}\n".format(var)
-
-    logger.info(msg)
-
-    failed_tests = []
-
-    try:
-        env.deploy()
-        for t in testcases:
-            logger.info("Running test case '{}' ...".format(t.name))
-
-            exit_code = t.run()
-            if (exit_code == TrfmTestCase.EX_OK):
-                logger.success("The test '{}' finished successfuly".
-                               format(t.name))
-            else:
-                failed_tests.append(t.name)
-                logger.error("The test '{}' finished with error code={}".
-                             format(t.name, exit_code))
-
-    except Exception as e:
-        logger.error("Something went wrong:\n{}".format(e))
         if (not no_clean):
             env.clean()
-        raise(e)
 
-    if (not no_clean):
-        env.clean()
-
-    if (len(testcases) > 1):
-        if (len(failed_tests) > 0):
+        if (len(testcases[tf_file]) > 1 and len(failed_tests) > 0):
             logger.error("The following tests failed: {}".
-                         format(failed_tests))
+                         format(",".join(failed_tests)))
             sys.exit(TrfmTestCase.EX_FAILURE)
-        else:
-            logger.success("All tests passed")
-            sys.exit(TrfmTestCase.EX_OK)
+
+    logger.success("All tests passed")
+    sys.exit(TrfmTestCase.EX_OK)

--- a/qatrfm/environment.py
+++ b/qatrfm/environment.py
@@ -134,7 +134,7 @@ class TerraformEnv(object):
             sys.exit(-1)
 
         try:
-            cmd = ("terraform apply -auto-approve "
+            cmd = ("terraform apply -input=false -auto-approve "
                    "-var 'basename={}' -var 'net_octet={}' {}".
                    format(self.basename, self.net_octet, self.tf_vars))
             if ('LOG_COLORS' not in os.environ):
@@ -190,7 +190,7 @@ class TerraformEnv(object):
                     except libutils.TrfmSnapshotFailed as e:
                         shutil.rmtree(self.workdir)
                         raise(e)
-            cmd = ("terraform destroy -auto-approve "
+            cmd = ("terraform destroy -input=false -auto-approve "
                    "-var 'basename={}' -var 'net_octet={}' {}".
                    format(self.basename, self.net_octet, self.tf_vars))
             if ('LOG_COLORS' not in os.environ):


### PR DESCRIPTION
Search in the given file/folder (`--test` param) for python files and load all
TrfmTestCase's corresponding to its tf_files automatically.

If a tf_file exists in the same folder as the `*.py` file, this tf file is used. Otherwise the `default.tf` file.

Next would be to have a --exclude-tests command line  parameter.

` qatrfm  --tfvar image=images/sle-15-SP1-x86_64-186.1-terraform@64bit.qcow2 -t tests/examples/simple/`
[single_test_run.log](https://github.com/jlausuch/qatrfm-lib/files/2965444/single_test_run.log)