### PR TITLE
Issue 5: Treat qemu-agent cmd as string

### DIFF
--- a/qatrfm/domain.py
+++ b/qatrfm/domain.py
@@ -60,6 +60,7 @@ class Domain(object):
         For more info about qemu agent, refer to:
             https://wiki.libvirt.org/page/Qemu_guest_agent
         """
+        cmd = cmd.replace('"', '\\"').replace('\n', '\\n')
         self.logger.debug("execute_cmd '{}'".format(cmd))
         str = qau.generate_guest_exec_str(self.name, cmd)
         out_json = libutils.execute_bash_cmd(str)[1]

--- a/qatrfm/utils/qemu_agent_utils.py
+++ b/qatrfm/utils/qemu_agent_utils.py
@@ -12,24 +12,10 @@ import json
 
 
 def generate_guest_exec_str(domain, cmd):
-    str = ("virsh -c qemu:///system qemu-agent-command --domain {} --cmd "
-           "\'{{ \"execute\": \"guest-exec\", \"arguments\": {{ \"path\": "
-           .format(domain))
-
-    if ' ' in cmd:
-        cmds = cmd.split(' ')
-        str += '\"{}\", \"arg\": ['.format(cmds[0])
-        i = 1
-        while i < len(cmds):
-            str += '\"{}\"'.format(cmds[i])
-            if (i < len(cmds) - 1):
-                str += ', '
-            i += 1
-        str += '], '
-    else:
-        str += '\"{}\", '.format(cmd)
-    str += '\"capture-output\": true }}\''
-    return str
+    return ('virsh -c qemu:///system qemu-agent-command --domain {} --cmd '
+            '\'{{ \"execute\": \"guest-exec\", \"arguments\": {{ \"path\": '
+            '\"bash\", \"arg\": [\"-c\", \"{}\"], \"capture-output\": true'
+            '}}}}\''.format(domain, cmd))
 
 
 def generate_guest_exec_status(domain, pid):

--- a/tests/examples/simple/simple_test.py
+++ b/tests/examples/simple/simple_test.py
@@ -21,6 +21,10 @@ class SimpleTest(TrfmTestCase):
 
         vm1 = self.env.domains[0]
 
+        # Using qemu-agent to execute commands
+        vm1.execute_cmd('echo -e "foo\nbar" > /root/some_file')
+        vm1.execute_cmd('cat /root/some_file | grep ba')
+
         # Transfering a file from a VM
         out_file = Path(self.env.workdir) / 'resolv.conf'
         vm1.transfer_file(remote_file_path='/etc/resolv.conf',


### PR DESCRIPTION
This allows using qemu-agent exec call as system() call. Therefore it is possible to use pipes, redirections, etc. 


bash -c command:
```
-c        If the -c option is present, then commands are read from the first non-option argument command_string.  If there are arguments after the  command_string,  the
                 first  argument  is  assigned  to  $0 and any remaining arguments are assigned to the positional parameters.  The assignment to $0 sets the name of the shell,
                 which is used in warning and error messages.
```

Proof run: https://pastebin.com/raw/TzMfsCRq